### PR TITLE
feat: add gradle extension that generates merged Manifest from json to markdown file

### DIFF
--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/AutodocPlugin.java
@@ -21,6 +21,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Gradle plugin that injects an {@code annotationProcessor} dependency to any Gradle project so that the autodoc processor can run during compile.
@@ -44,5 +45,13 @@ public class AutodocPlugin implements Plugin<Project> {
         project.getTasks().register(MergeManifestsTask.NAME, MergeManifestsTask.class, t -> t.dependsOn(AUTODOC_TASK_NAME).setGroup(GROUP_NAME));
         project.getTasks().register(MarkdownRendererTask.NAME, MarkdownRendererTask.class, t -> t.dependsOn(AUTODOC_TASK_NAME).setGroup(GROUP_NAME));
         project.getTasks().register(ManifestDownloadTask.NAME, ManifestDownloadTask.class, t -> t.setGroup(GROUP_NAME));
+        project.getTasks().register("jsonToMd", org.eclipse.edc.plugins.autodoc.tasks.MdWriter.class, mdWriter -> {
+            mdWriter.dependsOn("mergeManifest");
+            project.getTasks().getByName("mergeManifest").doLast(task -> {
+                org.eclipse.edc.plugins.autodoc.tasks.JsonReader jsonReader = new org.eclipse.edc.plugins.autodoc.tasks.JsonReader(project);
+                List<Map<String, Object>> objects = jsonReader.readJson();
+                mdWriter.setObjects(objects);
+            });
+        });
     }
 }

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/JsonReader.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/JsonReader.java
@@ -1,0 +1,38 @@
+package org.eclipse.edc.plugins.autodoc.tasks;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A class that reads a JSON file and creates a list of objects
+ */
+public class JsonReader {
+
+    private static final String MERGED_MANIFEST_FILENAME = "manifest.json";
+    private final ObjectMapper mapper;
+    private File jsonFile;
+
+    public JsonReader(Project project) {
+        mapper = new ObjectMapper();
+        jsonFile = new File(project.getRootProject().getBuildDir(), MERGED_MANIFEST_FILENAME);
+    }
+
+    public List<Map<String, Object>> readJson() {
+        if (!jsonFile.exists()) {
+            throw new GradleException("The JSON file does not exist!");
+        }
+
+        try {
+            return mapper.readValue(jsonFile, new TypeReference<List<Map<String, Object>>>() {});
+        } catch (IOException e) {
+            throw new GradleException("Error reading JSON file", e);
+        }
+    }
+}

--- a/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MdWriter.java
+++ b/plugins/autodoc/autodoc-plugin/src/main/java/org/eclipse/edc/plugins/autodoc/tasks/MdWriter.java
@@ -1,0 +1,114 @@
+package org.eclipse.edc.plugins.autodoc.tasks;
+
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A class that converts a list of objects to a Markdown table
+ */
+public class MdWriter extends DefaultTask {
+
+    private static final String DEFAULT_MD_FILENAME = "manifest.md";
+    private File destinationFile;
+    private List<Map<String, Object>> objects;
+
+    public MdWriter() {
+        setDestinationFile(new File(getProject().getRootProject().getBuildDir(), DEFAULT_MD_FILENAME));
+    }
+
+    @TaskAction
+    public void convertObjectsToMd() {
+        if (objects == null || objects.isEmpty()) {
+            throw new GradleException("The list of objects is empty!");
+        }
+
+        StringBuilder mdContent = new StringBuilder();
+
+        // add table headers
+        mdContent.append("| Name | Type | Overview | Class Name | Categories | Provides | References | Configuration | Version | Module Path |\n");
+        mdContent.append("|------|------|----------|------------|------------|----------|------------|---------------| ---------------|---------------|\n");
+
+        // iterate over each object, each object contains list of extensions
+        for (Map<String, Object> object : objects) {
+            List<Map<String, Object>> extensions = (List<Map<String, Object>>) object.get("extensions");
+            String version = (String) object.get("version");
+            String modulePath = (String) object.get("modulePath");
+
+            for (Map<String, Object> extension : extensions) {
+                mdContent.append("| ")
+                        .append(sanitize(extension.get("name")))
+                        .append(" | ")
+                        .append(sanitize(extension.get("type")))
+                        .append(" | ")
+                        .append(sanitize(extension.get("overview")))
+                        .append(" | ")
+                        .append(sanitize(extension.get("className")))
+                        .append(" | ")
+                        .append(sanitize(extension.get("categories")))
+                        .append(" | ")
+                        .append(sanitize(extension.get("provides")))
+                        .append(" | ")
+                        .append(sanitize(extension.get("references")))
+                        .append(" | ")
+                        .append(sanitize(extension.get("configuration")))
+                        .append(" | ")
+                        .append(sanitize(version))
+                        .append(" | ")
+                        .append(sanitize(modulePath))
+                        .append(" |\n");
+            }
+        }
+
+        try {
+            Files.writeString(destinationFile.toPath(), mdContent.toString());
+            getProject().getLogger().lifecycle("Generated the .md file at {}", destinationFile.getAbsolutePath());
+        } catch (IOException e) {
+            throw new GradleException("Error writing MD file", e);
+        }
+    }
+
+    /**
+     * The destination file. By default, it is set to {@code <rootProject>/build/manifest.md}
+     */
+    @OutputFile
+    public File getDestinationFile() {
+        return destinationFile;
+    }
+
+    public void setDestinationFile(File destinationFile) {
+        this.destinationFile = destinationFile;
+    }
+
+    /**
+     * The list of objects to convert to markdown. This should be set by the JsonReader class.
+     */
+    @Input
+    public List<Map<String, Object>> getObjects() {
+        return objects;
+    }
+
+    public void setObjects(List<Map<String, Object>> objects) {
+        this.objects = objects;
+    }
+
+    /**
+     * A Method that converts the input object into a string representation
+     * that does not contain any newline characters (\n) or pipe characters (|).
+     */
+    private String sanitize(Object input) {
+        if (input == null) return "";
+        String output = input.toString();
+        output = output.replace("\n", " ");
+        output = output.replace("|", "-");
+        return output;
+    }
+}


### PR DESCRIPTION
## What this PR changes/adds

Add Gradle extension that generates a markdown file from json file .

## Why it does that

To make the documentation more readable and user-friendly

## Further notes


## Linked Issue(s)

ref. #eclipse-edc/Connector#2710

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-edc/Connector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-edc/Connector/blob/main/pr_etiquette.md) for details_)
